### PR TITLE
Add GitHub Actions to label GitHub PR

### DIFF
--- a/.github/labeler.yaml
+++ b/.github/labeler.yaml
@@ -1,0 +1,13 @@
+version: 1
+labels:
+- label: ":robot: engineering"
+  files:
+  - ".github/.*"
+
+- label: "size/S"
+  size-below: 31
+- label: "size/M"
+  size-above: 30
+  size-below: 101
+- label: "size/L"
+  size-above: 100

--- a/.github/workflows/label-github-pr.yaml
+++ b/.github/workflows/label-github-pr.yaml
@@ -1,0 +1,16 @@
+name: Label PRs
+
+on:
+- pull_request
+
+jobs:
+  label-pr:
+    name: Label on Pull Request
+    runs-on: ubuntu-latest
+    steps:
+    - name: Add Labels for PR
+      uses: srvaroa/labeler@v0.6
+      env:
+        GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+      with:
+        config_path: ".github/labeler.yaml"


### PR DESCRIPTION
### Background

- Add trivial labels automatically on GitHub PRs